### PR TITLE
Add channel-based iterator for UnorderedSet, Benchmark, test cases update

### DIFF
--- a/set/unordered_set_bench_test.go
+++ b/set/unordered_set_bench_test.go
@@ -1,0 +1,110 @@
+package set
+
+import (
+	"strconv"
+	"testing"
+)
+
+func BenchmarkUnorderedSet_Insert(b *testing.B) {
+	set := NewUnorderedSet[int]()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		set.Insert(i)
+	}
+}
+
+func BenchmarkUnorderedSet_Contain(b *testing.B) {
+	set := NewUnorderedSet[float32]()
+	for i := 0; i < 10000000; i++ {
+		set.Insert(float32(i))
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		set.Contain(float32(i % 10000000))
+	}
+}
+
+func BenchmarkUnorderedSet_Remove(b *testing.B) {
+	set := NewUnorderedSet[int]()
+	for i := 0; i < b.N; i++ {
+		set.Insert(i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		set.Remove(i)
+	}
+}
+
+func BenchmarkUnorderedSet_Items(b *testing.B) {
+	set := NewUnorderedSet[int]()
+	for i := 0; i < 100000; i++ {
+		set.Insert(i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = set.Items()
+	}
+}
+
+func BenchmarkUnorderedSet_StringKeys(b *testing.B) {
+	set := NewUnorderedSet[string]()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		set.Insert(strconv.Itoa(i))
+	}
+}
+
+func BenchmarkUnorderedSet_ParallelInsert(b *testing.B) {
+	set := NewUnorderedSet[int]()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			set.Insert(i)
+			i++
+		}
+	})
+}
+
+func BenchmarkUnorderedSet_ParallelContain(b *testing.B) {
+	set := NewUnorderedSet[int]()
+	for i := 0; i < 100000; i++ {
+		set.Insert(i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			set.Contain(i % 100000)
+			i++
+		}
+	})
+}
+
+func BenchmarkUnorderedSet_ParallelRemove(b *testing.B) {
+	set := NewUnorderedSet[int]()
+	for i := 0; i < b.N; i++ {
+		set.Insert(i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			set.Remove(i)
+			i++
+		}
+	})
+}

--- a/set/unordered_set_test.go
+++ b/set/unordered_set_test.go
@@ -1,11 +1,12 @@
 package set
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestUnorderedSet_Clear(t *testing.T) {
-	set := NewUnorderedSet()
+	set := NewUnorderedSet[string]()
 
 	// Add elements to the set
 	set.Insert("apple")
@@ -28,7 +29,7 @@ func TestUnorderedSet_Clear(t *testing.T) {
 }
 
 func TestUnorderedSet_Insert(t *testing.T) {
-	set := NewUnorderedSet()
+	set := NewUnorderedSet[string]()
 	set.Insert("How")
 	set.Insert("Are")
 	set.Insert("How")
@@ -51,7 +52,7 @@ func TestUnorderedSet_Insert(t *testing.T) {
 }
 
 func TestUnorderedSet_Items(t *testing.T) {
-	set := NewUnorderedSet()
+	set := NewUnorderedSet[string]()
 
 	// Add elements to the set
 	set.Insert("apple")
@@ -83,7 +84,7 @@ func TestUnorderedSet_Items(t *testing.T) {
 }
 
 func TestUnorderedSet_Remove(t *testing.T) {
-	set := NewUnorderedSet()
+	set := NewUnorderedSet[string]()
 
 	// Add elements to the set
 	set.Insert("apple")
@@ -98,8 +99,19 @@ func TestUnorderedSet_Remove(t *testing.T) {
 		t.Errorf("Unexpected set size. Expected: %d, Got: %d", 2, set.Size())
 	}
 
-	// Check if removed element is no longer present in the set
+	// Check if a removed element is no longer present in the set
 	if set.Contain("banana") {
 		t.Error("Element 'banana' still found in the set after removal")
+	}
+}
+
+func TestUnorderedSet_Iter(t *testing.T) {
+	set := NewUnorderedSet[string]()
+	set.Insert("Franz Kafka")
+	set.Insert("Fyodor Dostoevsky")
+	set.Insert("Leo Tolstoy")
+	set.Insert("Friedrich Nietzsche")
+	for r := range set.Iter() {
+		fmt.Println(r)
 	}
 }


### PR DESCRIPTION
### Summary:
This PR introduces a new Iter() method to UnorderedSet that provides an idiomatic way to iterate over set elements using Go's for range syntax. The implementation uses a snapshot approach with a channel for safe, concurrent iteration.

### Key Changes:

- Added Iter() method to UnorderedSet:
  - Returns a read-only channel of elements.
  - Takes a snapshot of the set under a read lock to ensure thread safety.
  - Streams elements through a goroutine and closes the channel after iteration.
  - Benchmark test for set operations

Maintains concurrency safety without holding locks during iteration.
### Usage:
```go
for item := range set.Iter() {
    fmt.Println(item)
}
```

### Benefits:

- Go-idiomatic iteration using for range.
- Non-blocking for writers (snapshot-based).
- Safe for concurrent access.
- Simple and clean API for clients.

### Future Improvements:

- Add support for context cancellation to allow early termination of iteration.
- Provide benchmarks comparing Iter() with slice-based Items() for performance.